### PR TITLE
Upgrade lenses-topology-core to 4.0.0

### DIFF
--- a/lenses-topology-example-akkastreams/pom.xml
+++ b/lenses-topology-example-akkastreams/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <kafka.version>2.0.0</kafka.version>
         <java.version>1.8</java.version>
-        <topology.client.version>2.0.0</topology.client.version>
+        <topology.client.version>4.0.0</topology.client.version>
     </properties>
 
     <repositories>

--- a/lenses-topology-example-kafkastreams/pom.xml
+++ b/lenses-topology-example-kafkastreams/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <kafka.version>2.0.0</kafka.version>
         <java.version>1.8</java.version>
-        <topology.client.version>2.0.0</topology.client.version>
+        <topology.client.version>4.0.0</topology.client.version>
     </properties>
 
     <repositories>

--- a/lenses-topology-example-microservice/pom.xml
+++ b/lenses-topology-example-microservice/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <kafka.version>2.0.0</kafka.version>
         <java.version>1.8</java.version>
-        <topology.client.version>2.0.1</topology.client.version>
+        <topology.client.version>4.0.0</topology.client.version>
     </properties>
 
     <dependencies>

--- a/lenses-topology-example-sparkstreaming/pom.xml
+++ b/lenses-topology-example-sparkstreaming/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <kafka.version>2.0.0</kafka.version>
         <java.version>1.8</java.version>
-        <topology.client.version>2.0.0</topology.client.version>
+        <topology.client.version>4.0.0</topology.client.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
This simply upgrades lenses-topology-client version to its [latest release](https://search.maven.org/artifact/com.landoop/lenses-topology-client-core/4.0.0/jar).